### PR TITLE
Enhance Play Mode Switch UI and add one-shot reload

### DIFF
--- a/Editor/EnterPlayModeOptionsButton.cs
+++ b/Editor/EnterPlayModeOptionsButton.cs
@@ -1,168 +1,228 @@
 using UnityEditor;
 using UnityEngine;
+using System.Collections.Generic;
 
+// SECTION 1: THE FLOATING EDITOR WINDOW
 public class PlayModeSwitchWindow : EditorWindow
 {
-    private static readonly Color activeColor = new Color(0.1f, 0.6f, 1f);
-    private static readonly Color inactiveColor = new Color(0.3f, 0.3f, 0.3f);
-    private static readonly Color warningColor = new Color(1f, 0.5f, 0f);
-
+    [MenuItem("Tools/Play Mode/Play Once with Full Reload & Reset", false, 1)]
+    public static void PlayOnceWithFullReload()
+    {
+        PlayModeSwitchSettingsProvider.ArmOneShotReloadAndPlay();
+    }
+    
     [MenuItem("Window/Play Mode Switch")]
     public static void ShowWindow()
     {
         var window = GetWindow<PlayModeSwitchWindow>("Play Mode Switch");
-        window.minSize = new Vector2(300, 240);
+        window.minSize = new Vector2(380, 360);
     }
+    
+    private void OnEnable() => EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+    private void OnDisable() => EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+
+    private void OnPlayModeStateChanged(PlayModeStateChange state) => Repaint();
 
     private void OnGUI()
     {
-        EditorGUILayout.Space();
+        EditorGUILayout.BeginVertical(new GUIStyle { padding = new RectOffset(10, 10, 10, 10) });
+        PlayModeSwitchSettingsProvider.DrawSharedGui();
+        EditorGUILayout.EndVertical();
+    }
+}
+
+
+// SECTION 2: THE SETTINGS PROVIDER AND SHARED LOGIC
+// This class is decorated with [InitializeOnLoad] to handle state restoration after a domain reload.
+[InitializeOnLoad]
+class PlayModeSwitchSettingsProvider : SettingsProvider
+{
+    private enum PlayModeOption { ReloadDomainAndScene, ReloadSceneOnly, ReloadDomainOnly, DoNotReload, Custom }
+
+    // --- GUI Styles ---
+    private static readonly Color ActiveColor = new Color(0.1f, 0.6f, 1f, 1f);
+    private static readonly Color InactiveColor = new Color(0.3f, 0.3f, 0.3f, 1f);
+    private static readonly Color WarningColor = new Color(1f, 0.6f, 0.2f, 1f);
+    private static readonly Color OneShotColor = new Color(0.2f, 0.8f, 0.4f, 1f);
+
+    private static GUIStyle _activeButtonStyle, _inactiveButtonStyle, _warningLabelStyle, _oneShotButtonStyle;
+    private static readonly Dictionary<PlayModeOption, GUIContent> OptionContent = new Dictionary<PlayModeOption, GUIContent>();
+
+    // --- State Management using SessionState (to survive Domain Reloads) ---
+    private const string OneShotActiveKey = "PlayModeSwitch.OneShotReload.IsActive";
+    private const string OneShotOriginalEnabledKey = "PlayModeSwitch.OneShotReload.OriginalEnabled";
+    private const string OneShotOriginalOptionsKey = "PlayModeSwitch.OneShotReload.OriginalOptions";
+    
+    private static bool IsOneShotReloadActive
+    {
+        get => SessionState.GetBool(OneShotActiveKey, false);
+        set => SessionState.SetBool(OneShotActiveKey, value);
+    }
+
+    // --- Constructor and Registration ---
+    
+    static PlayModeSwitchSettingsProvider()
+    {
+        if (IsOneShotReloadActive)
+        {
+            EditorApplication.playModeStateChanged -= OnPlayModeChange_HandleOneShotReload;
+            EditorApplication.playModeStateChanged += OnPlayModeChange_HandleOneShotReload;
+        }
+    }
+
+    public PlayModeSwitchSettingsProvider(string path, SettingsScope scope) : base(path, scope) { }
+
+    [SettingsProvider]
+    public static SettingsProvider CreateSettingsProvider()
+    {
+        var provider = new PlayModeSwitchSettingsProvider("Project/Play Mode Switch", SettingsScope.Project)
+        {
+            keywords = new HashSet<string>(new[] { "Play", "Mode", "Reload", "Domain", "Scene", "Fast", "Reset" })
+        };
+        return provider;
+    }
+
+    // --- GUI Drawing ---
+    public override void OnGUI(string searchContext) => DrawSharedGui();
+
+    public static void DrawSharedGui()
+    {
+        InitializeStylesAndContent();
+
+        EditorGUI.BeginDisabledGroup(IsOneShotReloadActive);
+        
         EditorGUILayout.LabelField("Play Mode Settings", EditorStyles.largeLabel);
+        EditorGUILayout.Space(10);
+        EditorGUILayout.LabelField("Change Mode:", EditorStyles.boldLabel);
         EditorGUILayout.Space(5);
-
-        DrawCurrentSetting();
-        EditorGUILayout.Space(15);
-
         DrawOptions();
+        
+        EditorGUI.EndDisabledGroup();
+        
         EditorGUILayout.Space(15);
-
+        DrawOneShotReloadSection();
+        EditorGUILayout.Space(15);
         DrawInfoBox();
     }
-
-    private void DrawCurrentSetting()
+    
+    // --- GUI Drawing Helpers ---
+    private static void InitializeStylesAndContent()
     {
-        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-        EditorGUILayout.LabelField("Current Configuration", EditorStyles.boldLabel);
-        
+        if (_activeButtonStyle != null) return;
+        _activeButtonStyle = new GUIStyle(GUI.skin.button) { alignment = TextAnchor.MiddleLeft, padding = new RectOffset(10, 5, 5, 5), fixedHeight = 40, fontStyle = FontStyle.Bold, richText = true, normal = { textColor = Color.white } };
+        _inactiveButtonStyle = new GUIStyle(GUI.skin.button) { alignment = TextAnchor.MiddleLeft, padding = new RectOffset(10, 5, 5, 5), fixedHeight = 40, richText = true, normal = { textColor = new Color(0.8f, 0.8f, 0.8f) } };
+        _warningLabelStyle = new GUIStyle(EditorStyles.label) { wordWrap = true, normal = { textColor = WarningColor }, fontStyle = FontStyle.Bold };
+        _oneShotButtonStyle = new GUIStyle(GUI.skin.button) { alignment = TextAnchor.MiddleCenter, fixedHeight = 45, fontStyle = FontStyle.Bold, fontSize = 13, richText = true, normal = { textColor = Color.white } };
+
+        OptionContent[PlayModeOption.ReloadDomainAndScene] = new GUIContent(" Reload Domain & Scene", EditorGUIUtility.IconContent("d_Refresh").image, "Default Unity behavior. Slowest but safest.");
+        OptionContent[PlayModeOption.ReloadSceneOnly] = new GUIContent(" Reload Scene Only (Fast Play)", EditorGUIUtility.IconContent("SceneLoadIn").image, "Skips C# code reload. Much faster entry.");
+        OptionContent[PlayModeOption.ReloadDomainOnly] = new GUIContent(" Reload Domain Only", EditorGUIUtility.IconContent("cs Script Icon").image, "Reloads C# code but keeps the scene.");
+        OptionContent[PlayModeOption.DoNotReload] = new GUIContent(" Do Not Reload (Fastest)", EditorGUIUtility.IconContent("d_SpeedScale").image, "Fastest but most likely to cause issues.");
+    }
+    
+    private static void DrawOptions()
+    {
         var currentOption = GetCurrentOption();
-        var rect = EditorGUILayout.GetControlRect();
-        EditorGUI.LabelField(new Rect(rect.x, rect.y, rect.width * 0.6f, rect.height), "Mode:");
-        EditorGUI.LabelField(new Rect(rect.x + rect.width * 0.6f, rect.y, rect.width * 0.4f, rect.height), 
-                            currentOption, 
-                            new GUIStyle(EditorStyles.label) { fontStyle = FontStyle.Bold });
-        
-        EditorGUILayout.EndVertical();
+        DrawOptionButton(PlayModeOption.ReloadDomainAndScene, currentOption);
+        DrawOptionButton(PlayModeOption.ReloadSceneOnly, currentOption);
+        DrawOptionButton(PlayModeOption.ReloadDomainOnly, currentOption);
+        DrawOptionButton(PlayModeOption.DoNotReload, currentOption);
+        if (currentOption == PlayModeOption.Custom) { EditorGUILayout.HelpBox("Your Enter Play Mode settings are in a custom configuration.", MessageType.Warning); }
     }
-
-    private void DrawOptions()
+    
+    private static void DrawOneShotReloadSection()
     {
-        EditorGUILayout.LabelField("Change Mode:", EditorStyles.boldLabel);
-        
-        DrawOptionButton("Reload Domain & Scene", 
-                        "Traditional Unity behavior.\nFully resets everything when entering Play mode.",
-                        !EditorSettings.enterPlayModeOptionsEnabled);
-        
-        DrawOptionButton("Reload Scene Only", 
-                        "Keeps loaded assemblies in memory.\nFaster but may cause issues with static variables.",
-                        EditorSettings.enterPlayModeOptionsEnabled && 
-                        EditorSettings.enterPlayModeOptions == EnterPlayModeOptions.DisableDomainReload);
-        
-        DrawOptionButton("Reload Domain Only", 
-                        "Keeps the current scene state.\nUseful when working with complex scene setups.",
-                        EditorSettings.enterPlayModeOptionsEnabled && 
-                        EditorSettings.enterPlayModeOptions == EnterPlayModeOptions.DisableSceneReload);
-        
-        DrawOptionButton("Do Not Reload", 
-                        "Fastest but most dangerous option.\nMay cause unexpected behavior.",
-                        EditorSettings.enterPlayModeOptionsEnabled && 
-                        EditorSettings.enterPlayModeOptions == (EnterPlayModeOptions.DisableDomainReload | EnterPlayModeOptions.DisableSceneReload));
-    }
-
-    private void DrawOptionButton(string label, string tooltip, bool isActive)
-    {
-        var style = new GUIStyle(GUI.skin.button)
+        EditorGUILayout.LabelField("For Resetting Static Values:", EditorStyles.boldLabel);
+        if (IsOneShotReloadActive)
         {
-            alignment = TextAnchor.MiddleLeft,
-            padding = new RectOffset(15, 5, 5, 5),
-            fixedHeight = 30
-        };
-
-        var bgColor = isActive ? activeColor : inactiveColor;
-        var textColor = isActive ? Color.white : new Color(0.8f, 0.8f, 0.8f);
-
-        var origColor = GUI.backgroundColor;
-        var origTextColor = GUI.contentColor;
-
-        GUI.backgroundColor = bgColor;
-        GUI.contentColor = textColor;
-
-        if (GUILayout.Button(new GUIContent(label, tooltip), style))
-        {
-            ApplyOption(label);
+            EditorGUILayout.HelpBox("ARMED: The next Play session will use a full Domain & Scene reload. Your previous setting will be restored when you exit Play Mode.", MessageType.Warning);
         }
-
-        GUI.backgroundColor = origColor;
-        GUI.contentColor = origTextColor;
-    }
-
-    private void ApplyOption(string option)
-    {
-        switch (option)
+        else
         {
-            case "Reload Domain & Scene":
-                EditorSettings.enterPlayModeOptionsEnabled = false;
-                break;
-            case "Reload Scene Only":
-                EditorSettings.enterPlayModeOptionsEnabled = true;
-                EditorSettings.enterPlayModeOptions = EnterPlayModeOptions.DisableDomainReload;
-                break;
-            case "Reload Domain Only":
-                EditorSettings.enterPlayModeOptionsEnabled = true;
-                EditorSettings.enterPlayModeOptions = EnterPlayModeOptions.DisableSceneReload;
-                break;
-            case "Do Not Reload":
-                EditorSettings.enterPlayModeOptionsEnabled = true;
-                EditorSettings.enterPlayModeOptions = EnterPlayModeOptions.DisableDomainReload | EnterPlayModeOptions.DisableSceneReload;
-                break;
+            var originalColor = GUI.backgroundColor;
+            GUI.backgroundColor = OneShotColor;
+            var buttonContent = new GUIContent(" Play Once with Full Reload & Reset", EditorGUIUtility.IconContent("PlayButton").image, "Enters Play Mode ONCE with full reload to fix static variables, then reverts to your chosen fast setting.");
+            if (GUILayout.Button(buttonContent, _oneShotButtonStyle)) { ArmOneShotReloadAndPlay(); }
+            GUI.backgroundColor = originalColor;
         }
     }
 
-    private void DrawInfoBox()
+    private static void DrawOptionButton(PlayModeOption option, PlayModeOption currentOption)
     {
-        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-        EditorGUILayout.LabelField("ℹ Information", EditorStyles.boldLabel);
-        
-        EditorGUILayout.LabelField("These settings control how Unity enters Play mode:", EditorStyles.wordWrappedMiniLabel);
-        
-        EditorGUILayout.Space(5);
-        EditorGUILayout.LabelField("• Domain Reload: Resets all C# code", EditorStyles.wordWrappedMiniLabel);
-        EditorGUILayout.LabelField("• Scene Reload: Resets the current scene", EditorStyles.wordWrappedMiniLabel);
-        
-        EditorGUILayout.Space(5);
-        
-        var warningStyle = new GUIStyle(EditorStyles.wordWrappedMiniLabel)
-        {
-            normal = { textColor = warningColor }
-        };
-        
-        EditorGUILayout.LabelField("⚠ Warning: Disabling reloads may cause unexpected behavior with static variables and scene objects.", warningStyle);
-        EditorGUILayout.EndVertical();
+        bool isActive = (option == currentOption);
+        var originalColor = GUI.backgroundColor;
+        GUI.backgroundColor = isActive ? ActiveColor : InactiveColor;
+        var style = isActive ? _activeButtonStyle : _inactiveButtonStyle;
+        if (GUILayout.Button(OptionContent[option], style)) { if (!isActive) ApplyOption(option, false); }
+        GUI.backgroundColor = originalColor;
     }
 
-    private string GetCurrentOption()
+    private static void DrawInfoBox()
     {
-        if (!EditorSettings.enterPlayModeOptionsEnabled)
-        {
-            return "Reload Domain & Scene";
-        }
+        EditorGUILayout.HelpBox("Disabling Domain or Scene Reload can significantly speed up entering Play Mode, but may lead to unexpected behavior with static variables or script initializations.", MessageType.Info);
+        EditorGUILayout.LabelField("⚠ If you experience issues, use the 'Play Once with Full Reload' button to perform a reset.", _warningLabelStyle);
+    }
 
+    // --- Core Logic ---
+    public static void ArmOneShotReloadAndPlay()
+    {
+        if (EditorApplication.isPlayingOrWillChangePlaymode) return;
+        
+        SessionState.SetBool(OneShotOriginalEnabledKey, EditorSettings.enterPlayModeOptionsEnabled);
+        SessionState.SetInt(OneShotOriginalOptionsKey, (int)EditorSettings.enterPlayModeOptions);
+        
+        IsOneShotReloadActive = true;
+        EditorApplication.playModeStateChanged += OnPlayModeChange_HandleOneShotReload;
+        
+        ApplyOption(PlayModeOption.ReloadDomainAndScene, true);
+        Debug.Log("ONE-SHOT: Armed for a full Domain & Scene reload. Entering Play Mode now...");
+        
+        EditorApplication.EnterPlaymode();
+    }
+
+    private static void OnPlayModeChange_HandleOneShotReload(PlayModeStateChange state)
+    {
+        if (state == PlayModeStateChange.EnteredEditMode)
+        {
+            bool originalEnabled = SessionState.GetBool(OneShotOriginalEnabledKey, false);
+            var originalOptions = (EnterPlayModeOptions)SessionState.GetInt(OneShotOriginalOptionsKey, 0);
+            
+            EditorSettings.enterPlayModeOptionsEnabled = originalEnabled;
+            EditorSettings.enterPlayModeOptions = originalOptions;
+            
+            IsOneShotReloadActive = false;
+            SessionState.EraseString(OneShotOriginalEnabledKey);
+            SessionState.EraseString(OneShotOriginalOptionsKey);
+            
+            EditorApplication.playModeStateChanged -= OnPlayModeChange_HandleOneShotReload;
+            
+            Debug.Log("ONE-SHOT: Exited Play Mode. Restored previous Play Mode settings.");
+            
+            if (EditorWindow.HasOpenInstances<PlayModeSwitchWindow>())
+            {
+                EditorWindow.GetWindow<PlayModeSwitchWindow>().Repaint();
+            }
+        }
+    }
+
+    private static void ApplyOption(PlayModeOption option, bool isOneShot)
+    {
+        switch (option) {
+            case PlayModeOption.ReloadDomainAndScene: EditorSettings.enterPlayModeOptionsEnabled = false; break;
+            case PlayModeOption.ReloadSceneOnly: EditorSettings.enterPlayModeOptionsEnabled = true; EditorSettings.enterPlayModeOptions = EnterPlayModeOptions.DisableDomainReload; break;
+            case PlayModeOption.ReloadDomainOnly: EditorSettings.enterPlayModeOptionsEnabled = true; EditorSettings.enterPlayModeOptions = EnterPlayModeOptions.DisableSceneReload; break;
+            case PlayModeOption.DoNotReload: EditorSettings.enterPlayModeOptionsEnabled = true; EditorSettings.enterPlayModeOptions = EnterPlayModeOptions.DisableDomainReload | EnterPlayModeOptions.DisableSceneReload; break;
+        }
+        if(!isOneShot) { Debug.Log($"Play Mode setting changed to: {option}"); }
+    }
+
+    private static PlayModeOption GetCurrentOption()
+    {
+        if (!EditorSettings.enterPlayModeOptionsEnabled) return PlayModeOption.ReloadDomainAndScene;
         var options = EditorSettings.enterPlayModeOptions;
-
-        if (options == EnterPlayModeOptions.DisableDomainReload)
-        {
-            return "Reload Scene Only";
-        }
-
-        if (options == EnterPlayModeOptions.DisableSceneReload)
-        {
-            return "Reload Domain Only";
-        }
-
-        if (options == (EnterPlayModeOptions.DisableDomainReload | EnterPlayModeOptions.DisableSceneReload))
-        {
-            return "Do Not Reload";
-        }
-
-        return "Custom Configuration";
+        if (options == EnterPlayModeOptions.DisableDomainReload) return PlayModeOption.ReloadSceneOnly;
+        if (options == EnterPlayModeOptions.DisableSceneReload) return PlayModeOption.ReloadDomainOnly;
+        if (options == (EnterPlayModeOptions.DisableDomainReload | EnterPlayModeOptions.DisableSceneReload)) return PlayModeOption.DoNotReload;
+        return PlayModeOption.Custom;
     }
 }


### PR DESCRIPTION
Refactors and expands the Play Mode Switch editor window with improved UI, clearer options, and a new 'Play Once with Full Reload' feature for resetting static variables. Adds robust state management to restore previous settings after a one-shot reload, and centralizes shared logic in a SettingsProvider for consistency across the editor window and project settings.